### PR TITLE
Install blueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 npm-debug.log
 testem.log
 .idea/*
+.tern-port

--- a/blueprints/ember-country-region-selector/index.js
+++ b/blueprints/ember-country-region-selector/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  normalizeEntityName: function () {}, // no-op
+
+  afterInstall: function () {
+    return this.addBowerPackagesToProject([
+      {name: 'country-region-selector', target: '~0.2.2'}
+    ]);
+  }
+};

--- a/index.js
+++ b/index.js
@@ -5,6 +5,6 @@ module.exports = {
   name: 'ember-country-region-selector',
 
   included: function(app) {
-    app.import('bower_components/country-region-selector/dist/crs.min.js');
+    app.import(app.bowerDirectory + '/country-region-selector/dist/crs.js');
   }
 };


### PR DESCRIPTION
This adds a default blueprint which, when run, adds the country-region-selector dependency to the host application's bower.json.

This means that one can do `ember install ember-country-region-selector` (after it's published), and it will automatically pull the dependency.

We also normalize the path to bower components, as it's technically not safe to assume it's at `bower_components`
